### PR TITLE
route restructure 

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,0 +1,17 @@
+import { Response, NextFunction } from 'express'
+import { IReqAuth } from '../interface'
+
+const auth = async (req: IReqAuth, res: Response, next: NextFunction) => {
+    try {
+        if (req.isAuthenticated()) {
+            return next()
+        } else {
+            res.redirect('/')
+        }
+
+    } catch (err: any) {
+        return res.status(500).json({ msg: err.message })
+    }
+}
+
+export default auth

--- a/backend/src/routes/authRouter.ts
+++ b/backend/src/routes/authRouter.ts
@@ -1,0 +1,59 @@
+import dotenv from 'dotenv'
+dotenv.config()
+
+import express from 'express'
+import auth from '../middleware/auth'
+import { Request, Response } from 'express'
+import { IReqAuth } from '../interface'
+import passport from 'passport'
+
+const router = express.Router()
+
+// --- Discord ---
+router.get('/auth/discord', (req, res, next) => {
+    passport.authenticate('discord')(req, res, next)
+})
+
+router.get('/auth/discord/callback',
+    passport.authenticate('discord', {
+        failureRedirect: '/',
+        session: true
+    }),
+    function (req: Request, res: Response) {
+        res.redirect(`${process.env.FRONTEND_DEV_URL}/profile`)
+    })
+
+// --- Twitter ---
+router.get('/auth/twitter',
+    passport.authenticate('twitter'))
+
+router.get('/auth/twitter/callback',
+    passport.authenticate('twitter', {
+        failureRedirect: '/',
+        session: true
+    }),
+    function (req: Request, res: Response) {
+        res.redirect(`${process.env.FRONTEND_DEV_URL}/profile`)
+    })
+
+// --- GitHub ---
+router.get('/auth/github',
+    passport.authenticate('github', { scope: ['read:user'] }))
+
+router.get('/auth/github/callback',
+    passport.authenticate('github', {
+        failureRedirect: '/',
+        session: true
+    }),
+    function (req: Request, res: Response) {
+        res.redirect(`${process.env.FRONTEND_DEV_URL}/profile`)
+    })
+
+router.get('/auth/logout', auth, (req: IReqAuth, res: Response) => {
+    if (req.user) {
+        req.logout()
+        res.send('done')
+    }
+})
+
+export default router

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,0 +1,9 @@
+import authRouter from './authRouter'
+// import userRouter from './userRouter'
+
+const routes = [
+    authRouter,
+    // userRouter
+]
+
+export default routes

--- a/backend/src/strategies/discord.ts
+++ b/backend/src/strategies/discord.ts
@@ -1,13 +1,13 @@
 
-const DiscordStrategy = require("passport-discord").Strategy;
-import User from "../User";
-import { IDatabaseUser } from "../interface"
+const DiscordStrategy = require('passport-discord').Strategy;
+import User from '../User';
+import { IDatabaseUser } from '../interface'
 
 const discordScopes = ['identify', 'guilds', 'guilds.join', 'guilds.members.read']
 const discordStrategySettings: any = {
     clientID: `${process.env.DISCORD_CLIENT_ID}`,
     clientSecret: `${process.env.DISCORD_CLIENT_SECRET}`,
-    callbackURL: "/auth/discord/callback",
+    callbackURL: '/api/auth/discord/callback',
     scope: discordScopes
 }
 export const discordStrategy: any = new DiscordStrategy(discordStrategySettings, handleDiscordLogin);

--- a/backend/src/strategies/github.ts
+++ b/backend/src/strategies/github.ts
@@ -1,9 +1,9 @@
-const GitHubStrategy = require("passport-github2").Strategy
+const GitHubStrategy = require('passport-github2').Strategy
 
 const gitHubStrategySettings: any = {
     clientID: `${process.env.GITHUB_CLIENT_ID}`,
     clientSecret: `${process.env.GITHUB_CLIENT_SECRET}`,
-    callbackURL: "/auth/github/callback",
+    callbackURL: '/api/auth/github/callback',
     passReqToCallback: true
 }
 export const gitHubStrategy: any = new GitHubStrategy(gitHubStrategySettings, handleConnectGitHubAccount);

--- a/backend/src/strategies/twitter.ts
+++ b/backend/src/strategies/twitter.ts
@@ -1,10 +1,10 @@
-const TwitterStrategy = require("passport-twitter").Strategy
+const TwitterStrategy = require('passport-twitter').Strategy
 
 
 const twitterStrategySettings: any = {
     consumerKey: `${process.env.TWITTER_CONSUMER_KEY}`,
     consumerSecret: `${process.env.TWITTER_CONSUMER_SECRET}`,
-    callbackURL: "/auth/twitter/callback",
+    callbackURL: '/api/auth/twitter/callback',
     skipExtendedUserProfile: true,
     passReqToCallback: true
 }

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="A social media app that helps connect software engineers"
+      content="An open-source app created to help connect 100Devs cohort members across multiple platforms"
     />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -51,11 +51,11 @@ export default function Navbar() {
     const [showModal, setShowModal] = useState(false)
 
     const discordLogin = () => {
-        window.open("http://localhost:4000/auth/discord?testworking=true&happiness=high", "_self")
+        window.open("http://localhost:4000/api/auth/discord")
     }
 
     const logout = () => {
-        axios.get("http://localhost:4000/auth/logout", {
+        axios.get("http://localhost:4000/api/auth/logout", {
             withCredentials: true
         }).then((res: AxiosResponse) => {
             if (res.data === "done") {

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -49,11 +49,11 @@ const LoginContainer = tw.div`px-10 py-2 flex-col flex`
 export default function Profile() {
 
     const gitHubConnect = () => {
-        window.open("http://localhost:4000/auth/github", "_self")
+        window.open("http://localhost:4000/api/auth/github", "_self")
     }
 
     const twitterConnect = () => {
-        window.open("http://localhost:4000/auth/twitter", "_self")
+        window.open("http://localhost:4000/api/auth/twitter", "_self")
     }
 
     const [showModal, setShowModal] = useState(false)


### PR DESCRIPTION
edit: oauth routes and logout moved to a routes/authRouter.ts | add: structure setup for all routers to go through routes/index.ts 

**note app.use('/api', routes) in our server file now maps the path '/api' at the start of all routes. you'll need to update your OAuth callbacks ex.  http://localhost:4000/auth/discord/callback => http://localhost:4000/api/auth/discord/callback